### PR TITLE
Only link to Panic Guide when a URL is given

### DIFF
--- a/v1_1/check.go
+++ b/v1_1/check.go
@@ -1,6 +1,9 @@
 package v1_1
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 type Check struct {
 	ID               string
@@ -20,6 +23,7 @@ func (ch *Check) runChecker() CheckResult {
 		BusinessImpact:   ch.BusinessImpact,
 		TechnicalSummary: ch.TechnicalSummary,
 		PanicGuide:       ch.PanicGuide,
+		PanicGuideIsLink: strings.HasPrefix(ch.PanicGuide, "http"),
 		LastUpdated:      time.Now(),
 	}
 	out, err := ch.Checker()

--- a/v1_1/handler.go
+++ b/v1_1/handler.go
@@ -66,7 +66,8 @@ func writeHTMLResp(w http.ResponseWriter, health HealthResult) error {
 						<li> Severity: {{ $value.Severity }} </li>
                                                 <li> Business impact: {{ $value.BusinessImpact }} </li>
                                                 <li> Technical summary: {{ $value.TechnicalSummary }} </li>
-						<li> Panic guide: <a href="{{ $value.PanicGuide }}">{{ $value.PanicGuide }}</a> </li>
+						{{if $value.PanicGuideIsLink }}<li> Panic guide: <a href="{{ $value.PanicGuide }}">{{ $value.PanicGuide }}</a> </li>
+						{{ else }}<li> Panic guide: <pre>{{ $value.PanicGuide }}</pre> </li>{{ end }}
 						<li> Output: {{ $value.CheckOutput }} </li>
                                                 <li> Last updated: {{ $value.LastUpdated }} </li>
                                             </ul>

--- a/v1_1/result.go
+++ b/v1_1/result.go
@@ -15,6 +15,7 @@ type CheckResult struct {
 	CheckOutput      string    `json:"checkOutput"`
 	LastUpdated      time.Time `json:"lastUpdated"`
 	Ack              string    `json:"ack,omitempty"`
+	PanicGuideIsLink bool      `json:"-"`
 }
 
 type HealthResult struct {


### PR DESCRIPTION
The healthcheck standard allows for panic guides to provided inline, rather than a link to a doc.  At the moment when we do this, they look a bit silly because our html representation attempts to create a link anyway.