### PR TITLE
Handle panics thrown in checker function

### DIFF
--- a/v1_1/check.go
+++ b/v1_1/check.go
@@ -76,8 +76,8 @@ func (ch *Check) check() (string, error) {
 					default:
 						err = errors.New("Unknown error")
 					}
+					resultCh <- result{"", err}
 				}
-				resultCh <- result{"", err}
 				return
 			}()
 			out, err := ch.Checker()

--- a/v1_1/check.go
+++ b/v1_1/check.go
@@ -1,6 +1,7 @@
 package v1_1
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -17,8 +18,23 @@ type Check struct {
 	Timeout          time.Duration
 }
 
-func (ch *Check) runChecker() CheckResult {
-	result := CheckResult{
+func (ch *Check) runChecker() (result CheckResult) {
+
+	// Any panics hit during checking should cause the check to fail
+	defer func() {
+		if rec := recover(); rec != nil {
+			result.Ok = false
+			switch t := rec.(type) {
+				case string:
+					result.CheckOutput = t
+				case error:
+					result.CheckOutput = t.Error()
+				default:
+					result.CheckOutput = "Unknown error returned during check"
+			}
+		}
+	}()
+	result = CheckResult{
 		ID:               ch.ID,
 		Name:             ch.Name,
 		Severity:         ch.Severity,
@@ -36,7 +52,7 @@ func (ch *Check) runChecker() CheckResult {
 		result.Ok = true
 		result.CheckOutput = out
 	}
-	return result
+	return
 }
 
 func (ch *Check) check() (string, error) {
@@ -47,6 +63,23 @@ func (ch *Check) check() (string, error) {
 		}
 		resultCh := make(chan result)
 		go func() {
+
+			// Any panics hit during checking should cause the check to fail
+			defer func() {
+				var err error
+				if rec := recover(); rec != nil {
+					switch t := rec.(type) {
+					case string:
+						err = errors.New(t)
+					case error:
+						err = t
+					default:
+						err = errors.New("Unknown error")
+					}
+				}
+				resultCh <- result{"", err}
+				return
+			}()
 			out, err := ch.Checker()
 			resultCh <- result{out, err}
 		}()

--- a/v1_1/fthealth_test.go
+++ b/v1_1/fthealth_test.go
@@ -74,7 +74,7 @@ func verifyTimePassedOK(expDur time.Duration, actualDur time.Duration, tcName st
 func verifyResultOK(result HealthResult, expectedOverallSeverity uint8, tcName string, t *testing.T) {
 	expectedOK := expectedOverallSeverity == 0
 	if result.Ok != expectedOK {
-		t.Errorf("TC name: %s, Error was: expected overall status %b but actual was %b \n", tcName, true, result.Ok)
+		t.Errorf("TC name: %s, Error was: expected overall status %t but actual was %t \n", tcName, true, result.Ok)
 	}
 	if result.Severity != expectedOverallSeverity {
 		t.Errorf("TC name: %s, Error was: expected overall severity %d but actual was %d \n", tcName, expectedOverallSeverity, result.Severity)
@@ -125,6 +125,14 @@ func TestResultStatusAndSeverityForSequentialAndParallel(t *testing.T) {
 				return "", errors.New("Failure")
 			}}}},
 		{name: "Overall status and severity, with check error, parallel and timed", count: 3, delay: time.Millisecond * 1, parallel: true, timeout: 3 * time.Second, specialCheck: specialCheck{}},
+		{name: "Checker throws a panic, parallel", count: 1, parallel: true, timeout: 3 * time.Second,
+			specialCheck: specialCheck{true, Check{Severity: 2, Checker: func() (string, error) {
+				panic("Checker did something unexpected")
+			}}}},
+		{name: "Checker throws a panic, sequential", count: 1, parallel: false, timeout: 3 * time.Second,
+			specialCheck: specialCheck{true, Check{Severity: 2, Checker: func() (string, error) {
+				panic("Checker did something unexpected")
+			}}}},
 	}
 
 	for _, el := range testCases {


### PR DESCRIPTION
I've added a function to handle these in both parallel and sequential calls and return a `ok: true` on the check and pass the error message as the checkOutput